### PR TITLE
v1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,12 @@ A mob may belong to multiple categories; it will trigger a death message if at l
 - `hostile`: Mobs treated as hostile by the game's code.
 - `passive`: Mobs treated as passive by the game's code. This is _not_ the negation of `hostile; some mobs are neither hostile nor passive.
 
-(The game's builtin way of checking whether a mob can despawn is quite unreliable, so `persistent` and `ephemeral` may yield some unexpected results. In the future, I will need to handle a few exceptions for them to work as expected.)
-
 ### Custom categories
 Custom categories are defined in `.minecraft/config/alldeath-rules.json`.
 
 Each key in the root object is used as a category name. The associated value is an array of strings, representing the entity types that can trigger the gamerule.
 
-### Categories example
-This example is provided as the default config file.
+This example is provided as the default config file:
 ```json
 {
 	"utility": [

--- a/changelog.md
+++ b/changelog.md
@@ -22,9 +22,14 @@ Initial release
 - Added the ability to apply colours and styles to the mob names
 
 ## 1.5
+### 1.5.0
 - Added the ability to see entity coordinates in the Advanced Tooltips.
 - Added `persistent`, `ephemeral`, `hostile` and `passive` as built-in rules
 - Removed the `other` rule, now replaced with `all`.
 - Death messages for tamed entities are handled more reliably in multiplayer.
 - Builtin gamerules may now be overwritten by the rules in the config.
 - Installed MixinExtras and refactored all mixins.
+###	1.5.1
+- Added `/alldeathmsg test` command to check a mobs categories.
+- Jockeys, mobs in vehicles, and Endermen carrying blocks are no longer considered persistent.
+- The Wither and the Ender Dragon are no longer considered ephemeral.

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ loader_version=0.14.19
 fabric_version=0.79.0+1.19.4
 
 # Mod Properties
-mod_version = 1.5.0
+mod_version = 1.5.1
 maven_group = tk.estecka.alldeath
 archives_base_name = AllDeathMessages

--- a/src/main/java/tk/estecka/alldeath/AllDeathMessages.java
+++ b/src/main/java/tk/estecka/alldeath/AllDeathMessages.java
@@ -19,5 +19,6 @@ public class AllDeathMessages implements ModInitializer
 	public void	onInitialize(){
 		DeathRules.initialize();
 		DeathStyles.initialize();
+		Commands.Register();
 	}
 }

--- a/src/main/java/tk/estecka/alldeath/Commands.java
+++ b/src/main/java/tk/estecka/alldeath/Commands.java
@@ -1,0 +1,62 @@
+package tk.estecka.alldeath;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.command.CommandManager.RegistrationEnvironment;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import java.util.Collection;
+import static net.minecraft.server.command.CommandManager.literal;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.command.argument.EntityArgumentType.entities;
+import static net.minecraft.command.argument.EntityArgumentType.getEntities;
+
+public class Commands 
+{
+	static public final Identifier ID = new Identifier("alldeath", "command");
+	static private final String ENTITY_ARG = "entity";
+
+	static public void	Register(){
+		CommandRegistrationCallback.EVENT.register(ID, Commands::RegisterWith);
+	}
+
+	static public void RegisterWith(CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess, RegistrationEnvironment env){
+		var root = literal("alldeathmsg");
+
+		root.then(literal("test")
+			.then(argument(ENTITY_ARG, entities())
+				.executes(Commands::TestEntities)
+			)
+		);
+
+		dispatcher.register(root);
+	}
+
+	static private int	TestEntities(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		Collection<? extends Entity> entities = getEntities(context, ENTITY_ARG);
+
+		for (Entity e : entities)
+		{
+			MutableText result = Text.empty();
+			result.append(DeathStyles.getStyledName(e)).append(": ");
+			boolean first = true;
+			for (var predicate : EntityPredicates.predicates.entrySet())
+			if  (predicate.getValue().test(e)){
+				if (first)
+					first = false;
+				else
+					result.append(", ");
+				result.append(predicate.getKey());
+			}
+			context.getSource().sendFeedback(result, false);
+		}
+
+		return 0;
+	}
+}

--- a/src/main/java/tk/estecka/alldeath/DeathStyles.java
+++ b/src/main/java/tk/estecka/alldeath/DeathStyles.java
@@ -51,6 +51,10 @@ public class DeathStyles
 	static public final String CONFIG_FILE = "alldeath-styles.json";
 	static public final List<MobStyle> STYLES = new ArrayList<MobStyle>();
 
+	static public Text	getStyledName(Entity entity) {
+		return getStyledName(entity, entity.getDisplayName());
+	}
+
 	static public Text	getStyledName(Entity entity, Text name) {
 		MobStyle deathStyle = new MobStyle();
 		for (var s : STYLES)

--- a/src/main/java/tk/estecka/alldeath/EntityPredicates.java
+++ b/src/main/java/tk/estecka/alldeath/EntityPredicates.java
@@ -4,6 +4,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.boss.WitherEntity;
+import net.minecraft.entity.boss.dragon.EnderDragonEntity;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.PassiveEntity;
@@ -16,14 +18,19 @@ public class EntityPredicates {
 		put( "hostile",    EntityPredicates::HOSTILE    );
 		put( "passive",    EntityPredicates::PASSIVE    );
 		put( "ephemeral",  EntityPredicates::EPHEMERAL  );
+		put( "semi-persistent",  EntityPredicates::SEMIPERSISTENT);
 	}};
 
 	static public boolean	NAMED(Entity e) { return e.hasCustomName() || e.isPlayer(); }
 	static public boolean	HOSTILE(Entity e) { return e instanceof HostileEntity; }
 	static public boolean	PASSIVE(Entity e) { return e instanceof PassiveEntity; }
 	static public boolean	EPHEMERAL(Entity e) { return !PERSISTENT(e); }
+	static public boolean	SEMIPERSISTENT(Entity e) { return e instanceof MobEntity mob && mob.cannotDespawn(); }
 
 	static public boolean	PERSISTENT(Entity entity) {
+		if (entity instanceof WitherEntity || entity instanceof EnderDragonEntity)
+			return true;
+
 		if (!(entity instanceof MobEntity mob))
 			return false;
 

--- a/src/main/java/tk/estecka/alldeath/EntityPredicates.java
+++ b/src/main/java/tk/estecka/alldeath/EntityPredicates.java
@@ -23,12 +23,14 @@ public class EntityPredicates {
 	static public boolean	PASSIVE(Entity e) { return e instanceof PassiveEntity; }
 	static public boolean	EPHEMERAL(Entity e) { return !PERSISTENT(e); }
 
-	static public boolean	PERSISTENT(Entity e) {
-		if (!(e instanceof MobEntity))
+	static public boolean	PERSISTENT(Entity entity) {
+		if (!(entity instanceof MobEntity mob))
 			return false;
 
-		MobEntity m = (MobEntity)e;
-		return (m.isPersistent() || m.cannotDespawn() || !m.canImmediatelyDespawn(Double.POSITIVE_INFINITY));
+		return mob.isPersistent()
+			//|| m.cannotDespawn() 
+			|| !mob.canImmediatelyDespawn(Double.POSITIVE_INFINITY)
+			;
 	}
 
 	static public	Predicate<Entity>	getOrDefault(String name){


### PR DESCRIPTION
- Added `/alldeathmsg test` command to check a mobs categories.
- Jockeys, mobs in vehicles, and Endermen carrying blocks are no longer considered persistent.
- The Wither and the Ender Dragon are no longer considered ephemeral.